### PR TITLE
add calendar and reminder models, establish associations

### DIFF
--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -1,0 +1,70 @@
+class CalendarsController < ApplicationController
+  before_action :set_calendar, only: %i[ show edit update destroy ]
+
+  # GET /calendars or /calendars.json
+  def index
+    @calendars = Calendar.all
+  end
+
+  # GET /calendars/1 or /calendars/1.json
+  def show
+  end
+
+  # GET /calendars/new
+  def new
+    @calendar = Calendar.new
+  end
+
+  # GET /calendars/1/edit
+  def edit
+  end
+
+  # POST /calendars or /calendars.json
+  def create
+    @calendar = Calendar.new(calendar_params)
+
+    respond_to do |format|
+      if @calendar.save
+        format.html { redirect_to calendar_url(@calendar), notice: "Calendar was successfully created." }
+        format.json { render :show, status: :created, location: @calendar }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @calendar.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /calendars/1 or /calendars/1.json
+  def update
+    respond_to do |format|
+      if @calendar.update(calendar_params)
+        format.html { redirect_to calendar_url(@calendar), notice: "Calendar was successfully updated." }
+        format.json { render :show, status: :ok, location: @calendar }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @calendar.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /calendars/1 or /calendars/1.json
+  def destroy
+    @calendar.destroy
+
+    respond_to do |format|
+      format.html { redirect_to calendars_url, notice: "Calendar was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_calendar
+      @calendar = Calendar.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def calendar_params
+      params.require(:calendar).permit(:name)
+    end
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -13,6 +13,7 @@ class EventsController < ApplicationController
   # GET /events/new
   def new
     @event = Event.new
+    @calendars = Calendar.all
   end
 
   # GET /events/1/edit
@@ -65,6 +66,6 @@ class EventsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def event_params
-      params.require(:event).permit(:title, :date, :description)
+      params.require(:event).permit(:title, :date, :description, :calendar_id)
     end
 end

--- a/app/controllers/reminders_controller.rb
+++ b/app/controllers/reminders_controller.rb
@@ -1,0 +1,70 @@
+class RemindersController < ApplicationController
+  before_action :set_reminder, only: %i[ show edit update destroy ]
+
+  # GET /reminders or /reminders.json
+  def index
+    @reminders = Reminder.all
+  end
+
+  # GET /reminders/1 or /reminders/1.json
+  def show
+  end
+
+  # GET /reminders/new
+  def new
+    @reminder = Reminder.new
+  end
+
+  # GET /reminders/1/edit
+  def edit
+  end
+
+  # POST /reminders or /reminders.json
+  def create
+    @reminder = Reminder.new(reminder_params)
+
+    respond_to do |format|
+      if @reminder.save
+        format.html { redirect_to reminder_url(@reminder), notice: "Reminder was successfully created." }
+        format.json { render :show, status: :created, location: @reminder }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @reminder.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /reminders/1 or /reminders/1.json
+  def update
+    respond_to do |format|
+      if @reminder.update(reminder_params)
+        format.html { redirect_to reminder_url(@reminder), notice: "Reminder was successfully updated." }
+        format.json { render :show, status: :ok, location: @reminder }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @reminder.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /reminders/1 or /reminders/1.json
+  def destroy
+    @reminder.destroy
+
+    respond_to do |format|
+      format.html { redirect_to reminders_url, notice: "Reminder was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_reminder
+      @reminder = Reminder.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def reminder_params
+      params.require(:reminder).permit(:event_id, :remind_at, :message)
+    end
+end

--- a/app/helpers/calendars_helper.rb
+++ b/app/helpers/calendars_helper.rb
@@ -1,0 +1,2 @@
+module CalendarsHelper
+end

--- a/app/helpers/reminders_helper.rb
+++ b/app/helpers/reminders_helper.rb
@@ -1,0 +1,2 @@
+module RemindersHelper
+end

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -1,0 +1,7 @@
+class Calendar < ApplicationRecord
+    # Associations
+  has_many :events, dependent: :destroy
+
+  # Validations
+  validates :name, presence: true
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,2 +1,8 @@
 class Event < ApplicationRecord
+  # Associations
+  belongs_to :calendar
+  has_many :reminders, dependent: :destroy
+
+  # Validations
+  validates :title, :date, :description, presence: true
 end

--- a/app/models/reminder.rb
+++ b/app/models/reminder.rb
@@ -1,0 +1,8 @@
+class Reminder < ApplicationRecord
+  # Associations
+  belongs_to :event
+
+  # Validations
+  validates :remind_at, presence: true
+  validates :message, presence: true
+end

--- a/app/views/calendars/_calendar.html.erb
+++ b/app/views/calendars/_calendar.html.erb
@@ -1,0 +1,7 @@
+<div id="<%= dom_id calendar %>">
+  <p>
+    <strong>Name:</strong>
+    <%= calendar.name %>
+  </p>
+
+</div>

--- a/app/views/calendars/_calendar.json.jbuilder
+++ b/app/views/calendars/_calendar.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! calendar, :id, :name, :created_at, :updated_at
+json.url calendar_url(calendar, format: :json)

--- a/app/views/calendars/_form.html.erb
+++ b/app/views/calendars/_form.html.erb
@@ -1,0 +1,22 @@
+<%= form_with(model: calendar) do |form| %>
+  <% if calendar.errors.any? %>
+    <div style="color: red">
+      <h2><%= pluralize(calendar.errors.count, "error") %> prohibited this calendar from being saved:</h2>
+
+      <ul>
+        <% calendar.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :name, style: "display: block" %>
+    <%= form.text_field :name %>
+  </div>
+
+  <div>
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/calendars/edit.html.erb
+++ b/app/views/calendars/edit.html.erb
@@ -1,0 +1,10 @@
+<h1>Editing calendar</h1>
+
+<%= render "form", calendar: @calendar %>
+
+<br>
+
+<div>
+  <%= link_to "Show this calendar", @calendar %> |
+  <%= link_to "Back to calendars", calendars_path %>
+</div>

--- a/app/views/calendars/index.html.erb
+++ b/app/views/calendars/index.html.erb
@@ -1,0 +1,14 @@
+<p style="color: green"><%= notice %></p>
+
+<h1>Calendars</h1>
+
+<div id="calendars">
+  <% @calendars.each do |calendar| %>
+    <%= render calendar %>
+    <p>
+      <%= link_to "Show this calendar", calendar %>
+    </p>
+  <% end %>
+</div>
+
+<%= link_to "New calendar", new_calendar_path %>

--- a/app/views/calendars/index.json.jbuilder
+++ b/app/views/calendars/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @calendars, partial: "calendars/calendar", as: :calendar

--- a/app/views/calendars/new.html.erb
+++ b/app/views/calendars/new.html.erb
@@ -1,0 +1,9 @@
+<h1>New calendar</h1>
+
+<%= render "form", calendar: @calendar %>
+
+<br>
+
+<div>
+  <%= link_to "Back to calendars", calendars_path %>
+</div>

--- a/app/views/calendars/show.html.erb
+++ b/app/views/calendars/show.html.erb
@@ -1,0 +1,10 @@
+<p style="color: green"><%= notice %></p>
+
+<%= render @calendar %>
+
+<div>
+  <%= link_to "Edit this calendar", edit_calendar_path(@calendar) %> |
+  <%= link_to "Back to calendars", calendars_path %>
+
+  <%= button_to "Delete calendar", @calendar, method: :delete %>
+</div>

--- a/app/views/calendars/show.json.jbuilder
+++ b/app/views/calendars/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "calendars/calendar", calendar: @calendar

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -4,12 +4,18 @@
       <h2><%= pluralize(event.errors.count, "error") %> prohibited this event from being saved:</h2>
 
       <ul>
-        <% event.errors.each do |error| %>
-          <li><%= error.full_message %></li>
+        <% event.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
         <% end %>
       </ul>
     </div>
   <% end %>
+
+  <!-- Calendar Select Box -->
+  <div>
+    <%= form.label :calendar_id, style: "display: block" %>
+    <%= form.collection_select :calendar_id, @calendars, :id, :name, { include_blank: 'Select Calendar' }, { required: true } %>
+  </div>
 
   <div>
     <%= form.label :title, style: "display: block" %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -6,5 +6,5 @@
   <%= link_to "Edit this event", edit_event_path(@event) %> |
   <%= link_to "Back to events", events_path %>
 
-  <%= button_to "Destroy this event", @event, method: :delete %>
+  <%= button_to "Delete this event", @event, method: :delete %>
 </div>

--- a/app/views/reminders/_form.html.erb
+++ b/app/views/reminders/_form.html.erb
@@ -1,0 +1,32 @@
+<%= form_with(model: reminder) do |form| %>
+  <% if reminder.errors.any? %>
+    <div style="color: red">
+      <h2><%= pluralize(reminder.errors.count, "error") %> prohibited this reminder from being saved:</h2>
+
+      <ul>
+        <% reminder.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :event_id, style: "display: block" %>
+    <%= form.text_field :event_id %>
+  </div>
+
+  <div>
+    <%= form.label :remind_at, style: "display: block" %>
+    <%= form.datetime_field :remind_at %>
+  </div>
+
+  <div>
+    <%= form.label :message, style: "display: block" %>
+    <%= form.text_area :message %>
+  </div>
+
+  <div>
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/reminders/_reminder.html.erb
+++ b/app/views/reminders/_reminder.html.erb
@@ -1,0 +1,17 @@
+<div id="<%= dom_id reminder %>">
+  <p>
+    <strong>Event:</strong>
+    <%= reminder.event_id %>
+  </p>
+
+  <p>
+    <strong>Remind at:</strong>
+    <%= reminder.remind_at %>
+  </p>
+
+  <p>
+    <strong>Message:</strong>
+    <%= reminder.message %>
+  </p>
+
+</div>

--- a/app/views/reminders/_reminder.json.jbuilder
+++ b/app/views/reminders/_reminder.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! reminder, :id, :event_id, :remind_at, :message, :created_at, :updated_at
+json.url reminder_url(reminder, format: :json)

--- a/app/views/reminders/edit.html.erb
+++ b/app/views/reminders/edit.html.erb
@@ -1,0 +1,10 @@
+<h1>Editing reminder</h1>
+
+<%= render "form", reminder: @reminder %>
+
+<br>
+
+<div>
+  <%= link_to "Show this reminder", @reminder %> |
+  <%= link_to "Back to reminders", reminders_path %>
+</div>

--- a/app/views/reminders/index.html.erb
+++ b/app/views/reminders/index.html.erb
@@ -1,0 +1,14 @@
+<p style="color: green"><%= notice %></p>
+
+<h1>Reminders</h1>
+
+<div id="reminders">
+  <% @reminders.each do |reminder| %>
+    <%= render reminder %>
+    <p>
+      <%= link_to "Show this reminder", reminder %>
+    </p>
+  <% end %>
+</div>
+
+<%= link_to "New reminder", new_reminder_path %>

--- a/app/views/reminders/index.json.jbuilder
+++ b/app/views/reminders/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @reminders, partial: "reminders/reminder", as: :reminder

--- a/app/views/reminders/new.html.erb
+++ b/app/views/reminders/new.html.erb
@@ -1,0 +1,9 @@
+<h1>New reminder</h1>
+
+<%= render "form", reminder: @reminder %>
+
+<br>
+
+<div>
+  <%= link_to "Back to reminders", reminders_path %>
+</div>

--- a/app/views/reminders/show.html.erb
+++ b/app/views/reminders/show.html.erb
@@ -1,0 +1,10 @@
+<p style="color: green"><%= notice %></p>
+
+<%= render @reminder %>
+
+<div>
+  <%= link_to "Edit this reminder", edit_reminder_path(@reminder) %> |
+  <%= link_to "Back to reminders", reminders_path %>
+
+  <%= button_to "Remove reminder", @reminder, method: :delete %>
+</div>

--- a/app/views/reminders/show.json.jbuilder
+++ b/app/views/reminders/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "reminders/reminder", reminder: @reminder

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  resources :reminders
+  resources :calendars
   resources :events
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/db/migrate/20240116184409_create_calendars.rb
+++ b/db/migrate/20240116184409_create_calendars.rb
@@ -1,0 +1,9 @@
+class CreateCalendars < ActiveRecord::Migration[7.0]
+  def change
+    create_table :calendars do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240116184426_create_reminders.rb
+++ b/db/migrate/20240116184426_create_reminders.rb
@@ -1,0 +1,11 @@
+class CreateReminders < ActiveRecord::Migration[7.0]
+  def change
+    create_table :reminders do |t|
+      t.references :event, null: false, foreign_key: true
+      t.datetime :remind_at
+      t.text :message
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240116212532_add_calendar_id_to_events.rb
+++ b/db/migrate/20240116212532_add_calendar_id_to_events.rb
@@ -1,0 +1,7 @@
+class AddCalendarIdToEvents < ActiveRecord::Migration[7.0]
+  def change
+    add_column :events, :calendar_id, :integer
+    add_index :events, :calendar_id
+    add_foreign_key :events, :calendars
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_16_063630) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_16_212532) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "calendars", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "events", force: :cascade do |t|
     t.string "title"
@@ -20,6 +26,19 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_16_063630) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "calendar_id"
+    t.index ["calendar_id"], name: "index_events_on_calendar_id"
   end
 
+  create_table "reminders", force: :cascade do |t|
+    t.bigint "event_id", null: false
+    t.datetime "remind_at"
+    t.text "message"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["event_id"], name: "index_reminders_on_event_id"
+  end
+
+  add_foreign_key "events", "calendars"
+  add_foreign_key "reminders", "events"
 end

--- a/test/controllers/calendars_controller_test.rb
+++ b/test/controllers/calendars_controller_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class CalendarsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @calendar = calendars(:one)
+  end
+
+  test "should get index" do
+    get calendars_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_calendar_url
+    assert_response :success
+  end
+
+  test "should create calendar" do
+    assert_difference("Calendar.count") do
+      post calendars_url, params: { calendar: { name: @calendar.name } }
+    end
+
+    assert_redirected_to calendar_url(Calendar.last)
+  end
+
+  test "should show calendar" do
+    get calendar_url(@calendar)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_calendar_url(@calendar)
+    assert_response :success
+  end
+
+  test "should update calendar" do
+    patch calendar_url(@calendar), params: { calendar: { name: @calendar.name } }
+    assert_redirected_to calendar_url(@calendar)
+  end
+
+  test "should destroy calendar" do
+    assert_difference("Calendar.count", -1) do
+      delete calendar_url(@calendar)
+    end
+
+    assert_redirected_to calendars_url
+  end
+end

--- a/test/controllers/reminders_controller_test.rb
+++ b/test/controllers/reminders_controller_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class RemindersControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @reminder = reminders(:one)
+  end
+
+  test "should get index" do
+    get reminders_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_reminder_url
+    assert_response :success
+  end
+
+  test "should create reminder" do
+    assert_difference("Reminder.count") do
+      post reminders_url, params: { reminder: { event_id: @reminder.event_id, message: @reminder.message, remind_at: @reminder.remind_at } }
+    end
+
+    assert_redirected_to reminder_url(Reminder.last)
+  end
+
+  test "should show reminder" do
+    get reminder_url(@reminder)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_reminder_url(@reminder)
+    assert_response :success
+  end
+
+  test "should update reminder" do
+    patch reminder_url(@reminder), params: { reminder: { event_id: @reminder.event_id, message: @reminder.message, remind_at: @reminder.remind_at } }
+    assert_redirected_to reminder_url(@reminder)
+  end
+
+  test "should destroy reminder" do
+    assert_difference("Reminder.count", -1) do
+      delete reminder_url(@reminder)
+    end
+
+    assert_redirected_to reminders_url
+  end
+end

--- a/test/fixtures/calendars.yml
+++ b/test/fixtures/calendars.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/fixtures/reminders.yml
+++ b/test/fixtures/reminders.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  event: one
+  remind_at: 2024-01-16 13:44:26
+  message: MyText
+
+two:
+  event: two
+  remind_at: 2024-01-16 13:44:26
+  message: MyText

--- a/test/models/calendar_test.rb
+++ b/test/models/calendar_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CalendarTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/reminder_test.rb
+++ b/test/models/reminder_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ReminderTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/system/calendars_test.rb
+++ b/test/system/calendars_test.rb
@@ -1,0 +1,41 @@
+require "application_system_test_case"
+
+class CalendarsTest < ApplicationSystemTestCase
+  setup do
+    @calendar = calendars(:one)
+  end
+
+  test "visiting the index" do
+    visit calendars_url
+    assert_selector "h1", text: "Calendars"
+  end
+
+  test "should create calendar" do
+    visit calendars_url
+    click_on "New calendar"
+
+    fill_in "Name", with: @calendar.name
+    click_on "Create Calendar"
+
+    assert_text "Calendar was successfully created"
+    click_on "Back"
+  end
+
+  test "should update Calendar" do
+    visit calendar_url(@calendar)
+    click_on "Edit this calendar", match: :first
+
+    fill_in "Name", with: @calendar.name
+    click_on "Update Calendar"
+
+    assert_text "Calendar was successfully updated"
+    click_on "Back"
+  end
+
+  test "should destroy Calendar" do
+    visit calendar_url(@calendar)
+    click_on "Destroy this calendar", match: :first
+
+    assert_text "Calendar was successfully destroyed"
+  end
+end

--- a/test/system/reminders_test.rb
+++ b/test/system/reminders_test.rb
@@ -1,0 +1,45 @@
+require "application_system_test_case"
+
+class RemindersTest < ApplicationSystemTestCase
+  setup do
+    @reminder = reminders(:one)
+  end
+
+  test "visiting the index" do
+    visit reminders_url
+    assert_selector "h1", text: "Reminders"
+  end
+
+  test "should create reminder" do
+    visit reminders_url
+    click_on "New reminder"
+
+    fill_in "Event", with: @reminder.event_id
+    fill_in "Message", with: @reminder.message
+    fill_in "Remind at", with: @reminder.remind_at
+    click_on "Create Reminder"
+
+    assert_text "Reminder was successfully created"
+    click_on "Back"
+  end
+
+  test "should update Reminder" do
+    visit reminder_url(@reminder)
+    click_on "Edit this reminder", match: :first
+
+    fill_in "Event", with: @reminder.event_id
+    fill_in "Message", with: @reminder.message
+    fill_in "Remind at", with: @reminder.remind_at
+    click_on "Update Reminder"
+
+    assert_text "Reminder was successfully updated"
+    click_on "Back"
+  end
+
+  test "should destroy Reminder" do
+    visit reminder_url(@reminder)
+    click_on "Destroy this reminder", match: :first
+
+    assert_text "Reminder was successfully destroyed"
+  end
+end


### PR DESCRIPTION
## Description

This pull request introduces the necessary models and associations for the Event Scheduler application. It adds the Calendar, along with their associated Reminders. The key addition is the `calendar_id` field to the events table, enabling the linkage between Events and Calendars. This association is crucial for ensuring that all events are tied to a specific calendar, as enforced by the validations added to the Event model.

By establishing this relationship, the application can now handle the creation, updating, and deletion of events within a calendar, respecting the foreign key constraints at the application level using `dependent: :destroy`.

## Background Information
During the development of the Event Scheduler application, it was identified that events were not properly associated with calendars, leading to issues when trying to delete calendars with dependent events.

## Changelog

Internal changes:
- Added `calendar_id` column to the events table.
- Established `has_many :events, dependent: :destroy` association in the Calendar model.
- Established `belongs_to :calendar` association in the Event model.
- Added model validations to ensure the presence of titles, dates, and descriptions for events.

External changes:
- Enhanced the user interface to include a dropdown selection for calendars when creating a new event.
- Improved error messaging on the event creation form to better guide users through the process.

## Implications on main

After merging this branch, developers will need to run `rails db:migrate` to apply the new database schema changes. Additionally, developers should bundle install to ensure the gems are properly installed. It's important to note that events will now require a calendar to be saved, which may affect any seed data or test cases assuming the independence of events.
